### PR TITLE
feat: Refactor external app installation to use a JSON registry

### DIFF
--- a/components/apps/index.ts
+++ b/components/apps/index.ts
@@ -18,35 +18,43 @@ export const getAppDefinitions = async (): Promise<AppDefinition[]> => {
     return appDefinitions;
   }
 
-  // Use import.meta.glob to dynamically find all App.tsx files
-  const appModules = import.meta.glob([
+  // Use import.meta.glob to dynamically find all App.tsx files for internal apps
+  const internalAppModules = import.meta.glob([
     './*App.tsx',
     '../../window/components/**/*App.tsx',
     '../../window/components/*App.tsx',
   ]);
 
-  const definitions: AppDefinition[] = [];
-  for (const path in appModules) {
-    const module = await appModules[path]();
+  const internalDefinitions: AppDefinition[] = [];
+  for (const path in internalAppModules) {
+    const module = await internalAppModules[path]();
     if (hasAppDefinition(module)) {
-      definitions.push(module.appDefinition);
+      internalDefinitions.push(module.appDefinition);
     }
   }
 
-  // Manually add the external Chrome5 app definition, as it doesn't have a .tsx file
-  // and cannot be discovered by the glob pattern.
-  const chrome5AppDefinition: AppDefinition = {
-    id: 'chrome5',
-    name: 'Chrome 5',
-    icon: 'chrome5',
-    component: () => null, // Dummy component for external app
-    isExternal: true,
-    externalPath: 'components/apps/Chrome5/main.js',
-  };
-  definitions.push(chrome5AppDefinition);
+  // Fetch the list of registered external apps from our new JSON-based registry
+  let externalDefinitions: AppDefinition[] = [];
+  try {
+    const response = await fetch('http://localhost:3001/api/apps/external');
+    if (response.ok) {
+      const externalAppsData = await response.json();
+      // Add the dummy component property required by the AppDefinition type
+      externalDefinitions = externalAppsData.map((app: any) => ({
+        ...app,
+        component: () => null,
+      }));
+    }
+  } catch (error) {
+    console.error('Failed to fetch external apps:', error);
+    // Continue without external apps if the fetch fails
+  }
+
+  // Combine internal and external app definitions
+  const allDefinitions = [...internalDefinitions, ...externalDefinitions];
 
   // Cache the definitions so we don't reload them on every call
-  appDefinitions = definitions.sort((a, b) => a.name.localeCompare(b.name));
+  appDefinitions = allDefinitions.sort((a, b) => a.name.localeCompare(b.name));
 
   return appDefinitions;
 };

--- a/main/api.js
+++ b/main/api.js
@@ -33,11 +33,18 @@ function startApiServer() {
       const appsDir = path.join(FS_ROOT, 'components', 'apps');
       const entries = await fs.promises.readdir(appsDir, {withFileTypes: true});
 
-      const tsxFiles = new Set(
-        entries
-          .filter(e => e.isFile() && e.name.endsWith('App.tsx'))
-          .map(e => e.name),
-      );
+      const registryPath = path.join(FS_ROOT, 'main', 'data', 'external-apps.json');
+      let installedIds = new Set();
+      try {
+        const data = await fs.promises.readFile(registryPath, 'utf-8');
+        const installedApps = JSON.parse(data);
+        installedIds = new Set(installedApps.map(app => app.id));
+      } catch (error) {
+        if (error.code !== 'ENOENT') {
+          console.error('Could not read external app registry for checking installed status:', error);
+        }
+        // If file doesn't exist, installedIds remains an empty set, which is correct.
+      }
 
       const appPromises = entries
         .filter(entry => entry.isDirectory())
@@ -55,11 +62,12 @@ function startApiServer() {
               'utf-8',
             );
             const pkg = JSON.parse(content);
+            const appId = dir.name.toLowerCase();
 
-            const isInstalled = tsxFiles.has(`${dir.name}App.tsx`);
+            const isInstalled = installedIds.has(appId);
 
             return {
-              id: dir.name.toLowerCase(),
+              id: appId,
               name: dir.name,
               description: pkg.description || 'A discovered application.',
               version: pkg.version || '1.0.0',
@@ -81,52 +89,76 @@ function startApiServer() {
     }
   });
 
-  // Endpoint to "install" an app by creating its .tsx file
+  // API Endpoint to get the list of externally registered apps
+  apiApp.get('/api/apps/external', async (req, res) => {
+    try {
+      const filePath = path.join(FS_ROOT, 'main', 'data', 'external-apps.json');
+      const data = await fs.promises.readFile(filePath, 'utf-8');
+      res.setHeader('Content-Type', 'application/json');
+      res.send(data);
+    } catch (error) {
+      if (error.code === 'ENOENT') {
+        // If the file doesn't exist, return an empty array, which is valid.
+        res.json([]);
+      } else {
+        console.error('API Error getting external app list:', error);
+        res.status(500).json({error: 'Failed to get external app list'});
+      }
+    }
+  });
+
+  // Endpoint to "install" an app by adding it to the external-apps.json registry
   apiApp.post('/api/install', async (req, res) => {
-    const {id, name, path: appPath} = req.body;
+    const {id, name, path: appPath, version, description} = req.body;
     if (!id || !name || !appPath) {
       return res
         .status(400)
         .json({error: 'Missing required app details for installation.'});
     }
 
-    const componentName = `${name}App`;
-    const tsxFilePath = path.join(
-      FS_ROOT,
-      'components',
-      'apps',
-      `${componentName}.tsx`,
-    );
-
-    const tsxContent = `
-import React from 'react';
-import { AppDefinition, AppComponentProps } from '../../window/types';
-import { HyperIcon } from '../../window/constants'; // Using a generic icon
-
-const ${componentName}: React.FC<AppComponentProps> = () => {
-  // This component can be minimal as it's for an external app
-  return null;
-};
-
-export const appDefinition: AppDefinition = {
-  id: '${id}',
-  name: '${name}',
-  icon: 'hyper', // Assign a generic icon name as a string
-  isExternal: true,
-  externalPath: '${appPath}',
-  component: ${componentName},
-};
-
-export default ${componentName};
-`;
+    const registryPath = path.join(FS_ROOT, 'main', 'data', 'external-apps.json');
 
     try {
-      await fs.promises.writeFile(tsxFilePath, tsxContent.trim());
-      console.log(`Successfully created ${tsxFilePath}`);
-      res.status(201).json({success: true, message: `App ${name} installed.`});
+      let registry = [];
+      try {
+        const data = await fs.promises.readFile(registryPath, 'utf-8');
+        registry = JSON.parse(data);
+      } catch (error) {
+        if (error.code !== 'ENOENT') throw error;
+        // File doesn't exist, we'll create it with the new app.
+      }
+
+      const isAlreadyInstalled = registry.some(app => app.id === id);
+      if (isAlreadyInstalled) {
+        return res
+          .status(409)
+          .json({error: `App "${name}" is already installed.`});
+      }
+
+      const newAppEntry = {
+        id,
+        name,
+        icon: id, // Use the app's ID as a default icon identifier
+        isExternal: true,
+        externalPath: path.join(appPath, 'main.js'), // Point to the conventional entry point
+        version: version || '1.0.0',
+        description: description || 'An installed external application.',
+      };
+
+      registry.push(newAppEntry);
+
+      await fs.promises.writeFile(
+        registryPath,
+        JSON.stringify(registry, null, 2),
+      );
+
+      console.log(`Successfully added "${name}" to the external app registry.`);
+      res
+        .status(201)
+        .json({success: true, message: `App "${name}" installed.`});
     } catch (error) {
-      console.error(`Failed to write TSX file for ${name}:`, error);
-      res.status(500).json({error: `Failed to install app ${name}.`});
+      console.error(`Failed to install app "${name}":`, error);
+      res.status(500).json({error: `Failed to install app "${name}".`});
     }
   });
 

--- a/main/data/external-apps.json
+++ b/main/data/external-apps.json
@@ -1,0 +1,9 @@
+[
+  {
+    "id": "chrome5",
+    "name": "Chrome 5",
+    "icon": "chrome5",
+    "isExternal": true,
+    "externalPath": "components/apps/Chrome5/main.js"
+  }
+]


### PR DESCRIPTION
Replaces the faulty external application installer with a robust, data-driven registry system.

Previously, installing an external app from the App Store would generate a new `.tsx` file. This was the wrong approach for launching a separate Electron process and caused a "Cannot find module" error, preventing the app from launching.

This commit introduces the following changes:

1.  **JSON Registry:** A new `main/data/external-apps.json` file is created to act as a centralized registry for all installed external applications.

2.  **API Update:** The `/api/install` endpoint in `main/api.js` is rewritten. It no longer generates `.tsx` files. Instead, it adds a new entry to the `external-apps.json` registry. The `/api/apps` discovery endpoint is also updated to use this registry to determine which apps are installed.

3.  **Frontend Update:** The application loader in `components/apps/index.ts` now fetches the list of external apps from the new JSON registry, ensuring all external apps are loaded and launched using the correct, existing mechanism.

This new system fixes the bug, aligns the installation of all external apps with the successful pattern previously used only by "Chrome 5", and provides a cleaner, more maintainable architecture.